### PR TITLE
Don't discard markers needlessly.

### DIFF
--- a/lib/editor-decorator.coffee
+++ b/lib/editor-decorator.coffee
@@ -4,17 +4,18 @@
 
 markers = []
 
-module.exports = (editor) ->
-  m.destroy() for m in markers
-  markers = []
+module.exports =
+  decorate: (editor) ->
+    active = Stacktrace.getActivated()
+    return unless active?
 
-  active = Stacktrace.getActivated()
-  return unless active?
+    for frame in active.frames
+      if frame.realPath is editor.getPath()
+        range = editor.getBuffer().rangeForRow frame.bufferLineNumber()
+        marker = editor.markBufferRange range, persistent: false
+        editor.decorateMarker marker, type: 'line', class: 'line-stackframe'
+        editor.decorateMarker marker, type: 'gutter', class: 'gutter-stackframe'
+        markers.push marker
 
-  for frame in active.frames
-    if frame.realPath is editor.getPath()
-      range = editor.getBuffer().rangeForRow frame.bufferLineNumber()
-      marker = editor.markBufferRange range
-      editor.decorateMarker marker, type: 'line', class: 'line-stackframe'
-      editor.decorateMarker marker, type: 'gutter', class: 'gutter-stackframe'
-      markers.push marker
+  cleanup: ->
+    m.destroy() for m in markers

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -2,7 +2,7 @@ EnterDialog = require './enter-dialog'
 {Stacktrace} = require './stacktrace'
 {StacktraceView} = require './stacktrace-view'
 {NavigationView} = require './navigation-view'
-editorDecorator = require './editor-decorator'
+{decorate, cleanup} = require './editor-decorator'
 
 module.exports =
 
@@ -21,9 +21,11 @@ module.exports =
     atom.workspaceView.command 'stacktrace:follow-call', ->
       NavigationView.current()?.navigateToCalled()
 
-    atom.workspace.eachEditor editorDecorator
-    @activeChanged = Stacktrace.on 'active-changed', ->
-      editorDecorator(e) for e in atom.workspace.getEditors()
+    atom.workspace.eachEditor decorate
+    @activeChanged = Stacktrace.on 'active-changed', (e) ->
+      cleanup()
+      if e.newTrace?
+        decorate(e) for e in atom.workspace.getEditors()
 
     @navigationView = new NavigationView
     atom.workspaceView.appendToBottom @navigationView

--- a/spec/editor-decorator-spec.coffee
+++ b/spec/editor-decorator-spec.coffee
@@ -2,7 +2,7 @@ path = require 'path'
 {Editor, WorkspaceView} = require 'atom'
 
 {Stacktrace, Frame} = require '../lib/stacktrace'
-editorDecorator = require '../lib/editor-decorator'
+{decorate, cleanup} = require '../lib/editor-decorator'
 
 framePath = (fname) -> path.join __dirname, 'fixtures', fname
 
@@ -37,7 +37,7 @@ describe 'editorDecorator', ->
     expect(Stacktrace.getActivated()).toBeNull()
 
     withEditorOn 'bottom.rb', ->
-      editorDecorator(editor)
+      decorate(editor)
       expect(editorView.find '.line.line-stackframe').toHaveLength 0
 
   describe 'with an active trace', ->
@@ -46,19 +46,19 @@ describe 'editorDecorator', ->
 
     it "does nothing if the file doesn't appear in the active trace", ->
       withEditorOn 'context.txt', ->
-        editorDecorator(editor)
+        decorate(editor)
         expect(editorView.find '.line.line-stackframe').toHaveLength 0
 
     it 'decorates stackframe lines in applicable editors', ->
       withEditorOn 'bottom.rb', ->
-        editorDecorator(editor)
+        decorate(editor)
         decorated = editorView.find '.line.line-stackframe'
         expect(decorated).toHaveLength 1
         expect(decorated.text()).toEqual("  puts 'this is the stack line'")
 
     it 'removes prior decorations when deactivated', ->
       withEditorOn 'bottom.rb', ->
-        editorDecorator(editor)
+        decorate(editor)
         trace.deactivate()
-        editorDecorator(editor)
+        cleanup()
         expect(editorView.find '.line.line-stackframe').toHaveLength 0


### PR DESCRIPTION
Use `persistent: false` and a separate `cleanup()` function, instead.
