### PR TITLE
Stacktraces on stacktrace

### DIFF
--- a/lib/enter-dialog.coffee
+++ b/lib/enter-dialog.coffee
@@ -26,7 +26,7 @@ class EnterDialog extends View
     @subs.add atom.commands.add '.stacktrace.enter-dialog', 'core:cancel', => @cancel()
 
   traceIt: ->
-    @pkg.acceptTrace @traceEditor.getText()
+    @pkg.traceHandlerV1().acceptTrace @traceEditor.getText()
     @remove()
 
   cancel: -> @remove()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -12,11 +12,11 @@ module.exports =
 
   activate: (state) ->
     subs.add atom.commands.add 'atom-workspace',
-      'stacktrace:paste': -> atom.workspace.addTopPanel item: new EnterDialog
+      'stacktrace:paste': => atom.workspace.addTopPanel item: new EnterDialog(this)
       'stacktrace:from-selection': =>
         selections = atom.workspace.getActiveTextEditor()?.getSelections() or []
         text = (s.getText() for s in selections).join ''
-        @acceptTrace(text)
+        @traceHandlerV1().acceptTrace(text)
       'stacktrace:to-caller': -> NavigationView.current()?.navigateToCaller()
       'stacktrace:follow-call': -> NavigationView.current()?.navigateToCalled()
 
@@ -35,12 +35,17 @@ module.exports =
     @navigationView.remove()
     subs.dispose()
 
-  # Public: Parse any and all stacktraces recognized from a sample of text. Open a new
-  # StacktraceView for each.
+  # Public: Construct a service object that implements the stacktrace parsing service.
   #
-  # trace [String] - A sample of text that may contain zero to many stacktraces in recognized
-  #  languages.
-  acceptTrace: (trace) ->
-    for trace in Stacktrace.parse(trace)
-      trace.register()
-      atom.workspace.open trace.getUrl()
+  traceHandlerV1: ->
+
+    # Public: Parse any and all stacktraces recognized from a sample of text. Open a new
+    # StacktraceView for each.
+    #
+    # trace [String] - A sample of text that may contain zero to many stacktraces in recognized
+    #  languages.
+    #
+    acceptTrace: (trace) ->
+      for trace in Stacktrace.parse(trace)
+        trace.register()
+        atom.workspace.open trace.getUrl()

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "underscore-plus": "^1.5.1"
   },
   "providedServices": {
-    "stacktrace:accept-trace": {
+    "stacktrace:trace-handler": {
       "description": "Parse all stack traces recognized in sample of text and open a StacktraceView on each.",
-      "versions": { "1.0.0": "acceptTrace" }
+      "versions": { "1.0.0": "traceHandlerV1" }
     }
   }
 }

--- a/spec/enter-dialog-spec.coffee
+++ b/spec/enter-dialog-spec.coffee
@@ -11,7 +11,8 @@ describe 'EnterDialog', ->
 
   it 'calls an acceptTrace function', ->
     txt = null
-    pkg = acceptTrace: (t) -> txt = t
+    pkg = traceHandlerV1: ->
+      acceptTrace: (t) -> txt = t
 
     d = new EnterDialog(pkg)
     d.traceEditor.setText(TRACE)

--- a/styles/stacktrace.atom-text-editor.less
+++ b/styles/stacktrace.atom-text-editor.less
@@ -1,0 +1,14 @@
+@import "variables";
+
+.line.line-stackframe, .line.line-stackframe.cursor-line {
+  background: @stackframe-background;
+}
+
+// Work around some selector precedence issues.
+&.is-focused .line.line-stackframe, &.is-focused .line.line-stackframe.cursor-line {
+  background: @stackframe-background;
+}
+
+.gutter .line-number-stackframe {
+  background: @stackframe-gutter-background;
+}

--- a/styles/stacktrace.less
+++ b/styles/stacktrace.less
@@ -1,12 +1,4 @@
-// The ui-variables file is provided by base themes provided by Atom.
-//
-// See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
-// for a full listing of what's available.
-@import "ui-variables";
-@import "syntax-variables";
-
-@stackframe-background: mix(@background-color-info, @syntax-background-color, 40%);
-@stackframe-gutter-background: mix(@background-color-info, @syntax-gutter-background-color, 40%);
+@import "variables";
 
 .stacktrace {
   &.enter-dialog .editor {
@@ -90,19 +82,4 @@
     }
   }
 
-}
-
-atom-editor {
-  .line.line-stackframe, .line.line-stackframe.cursor-line {
-    background: @stackframe-background;
-  }
-
-  // Work around some selector precedence issues.
-  &.is-focused .line.line-stackframe, &.is-focused .line.line-stackframe.cursor-line {
-    background: @stackframe-background;
-  }
-
-  .gutter .line-number-stackframe {
-    background: @stackframe-gutter-background;
-  }
 }

--- a/styles/variables.less
+++ b/styles/variables.less
@@ -1,0 +1,10 @@
+// The ui-variables file is provided by base themes provided by Atom.
+//
+// See https://github.com/atom/atom-dark-ui/blob/master/stylesheets/ui-variables.less
+// for a full listing of what's available.
+
+@import "ui-variables";
+@import "syntax-variables";
+
+@stackframe-background: mix(@background-color-info, @syntax-background-color, 40%);
+@stackframe-gutter-background: mix(@background-color-info, @syntax-gutter-background-color, 40%);


### PR DESCRIPTION
This corrects a number of errors that were thrown while I was giving the package a spin with `--one` enabled.