### PR TITLE
Pointer cursor over mini editors

### DIFF
--- a/styles/stacktrace.less
+++ b/styles/stacktrace.less
@@ -1,7 +1,7 @@
 @import "variables";
 
 .stacktrace {
-  &.enter-dialog .editor {
+  &.enter-dialog atom-text-editor {
     height: 300px;
     max-height: 300px;
   }

--- a/styles/stacktrace.less
+++ b/styles/stacktrace.less
@@ -29,12 +29,14 @@
       .icon-fold { display: none; }
     }
 
-    .editor {
-      .editor-contents {
-        cursor: pointer;
-      }
+    atom-text-editor {
       height: 175px;
       max-height: 175px;
+      cursor: pointer;
+    }
+
+    atom-text-editor::shadow .scroll-view {
+      cursor: pointer;
     }
   }
 


### PR DESCRIPTION
This eliminates the last of the deprecated selectors in Deprecation Cop.
